### PR TITLE
feat: optionally extend the database port namespace and imports arrays

### DIFF
--- a/components/db/index.js
+++ b/components/db/index.js
@@ -3,6 +3,13 @@ const errorsFactory = require('./errors');
 module.exports = {
     ports: [
         function db(config = {}) {
+            const namespace = config.namespace
+                ? Array.from(new Set([`db/${config.service}`, ...config.namespace]))
+                : [`db/${config.service}`];
+            const imports = config.imports
+                ? Array.from(new Set([`db/${config.service}`, ...config.imports]))
+                : [`db/${config.service}`];
+
             return {
                 id: 'db',
                 createPort: require('ut-port-sql'),
@@ -10,8 +17,8 @@ module.exports = {
                 createTT: true,
                 createCRUD: true,
                 linkSP: true,
-                namespace: [`db/${config.service}`],
-                imports: [`db/${config.service}`],
+                namespace,
+                imports,
                 start() {
                     Object.assign(this.errors, errorsFactory(this.bus));
                 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ut-bus": ">=6.6.0-rc-einstein.0 <6.6.0"
   },
   "devDependencies": {
-    "ut-tools": "^5.32.10"
+    "ut-tools": "^5.32.11"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes an issue in ut-service, not allowing us to use other database schemas except the default one, defined by service name's value.